### PR TITLE
Fix for Support for Darwin would be useful here

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# karma-brave-launcher
+Launcher for [Brave](https://brave.com/)
+
+> NOTE: Windows support is not very good at the moment (meaning, very poor). Pull requests or pointers to docs to address this are welcomed.
+
+## Installation
+
+The easiest way is to keep `karma-brave-launcher` as a devDependency in your `package.json`,
+by running
+
+```bash
+$ npm install --save-dev karma-brave-launcher
+```
+
+## Configuration
+
+```js
+// karma.conf.js
+module.exports = function(config) {
+  config.set({
+    browsers: ['Brave']
+  })
+}
+```
+
+You can pass list of browsers as a CLI argument too:
+
+```bash
+$ karma start --browsers Brave
+```
+
+
+## References
+
+For more information on Karma see the [homepage](http://karma-runner.github.com)

--- a/index.js
+++ b/index.js
@@ -1,30 +1,76 @@
+var fs = require('fs');
+var path = require('path');
 var which = require('which');
 
-var BraveBrowser = function (baseBrowserDecorator, args) {
-  baseBrowserDecorator(this);
-
-};
+var WINDOWS_EXE_DIRS = [process.env.LOCALAPPDATA, process.env.PROGRAMFILES, process.env['PROGRAMFILES(X86)']];
+var WINDOWS_SUBPATH = '\\Brave\\Application\\brave.exe';
+var DARWIN_SUBPATH = 'Applications/Brave.app/Contents/MacOS/Brave';
 
 function getBin(command) {
   if (process.platform !== 'linux') {
     return null;
   }
+
   try {
     return which.sync(command);
   }
   catch(err){};
 }
 
+/*
+ * On darwin, try to find the browser at the path, relative to the 
+ * user's home directory, otherwise try to find it relative to the
+ * root directory
+ */
+function getPathToBraveOnDarwin(defaultPath) {
+  if (process.platform !== 'darwin') {
+    return;
+  }
+
+  var homePath = path.join(process.env.HOME, DARWIN_SUBPATH);
+  var rootPath = path.join('/', DARWIN_SUBPATH);
+
+  return fs.existsSync(homePath) ? homePath : rootPath;
+}
+
+/*
+ * On Windows, cycle through a set of special app locations, and look for it
+ * relative to those
+ */
+function getPathToBraveOnWindows() {
+  if (process.platform !== 'win32') {
+    return;
+  }
+
+  var windowsBraveDirectory;
+
+  for (var i = 0; i < WINDOWS_EXE_DIRS.length; i++) {
+    windowsBraveDirectory = path.join(prefixes[i], WINDOWS_SUBPATH);
+
+    if (fs.existsSync(windowsBraveDirectory)) {
+      return windowsBraveDirectory;
+    }
+  }
+
+  return windowsBraveDirectory;
+}
+
+function BraveBrowser(baseBrowserDecorator, args) {
+   baseBrowserDecorator(this);
+}
+
 BraveBrowser.prototype = {
   name: 'Brave',
   DEFAULT_CMD: {
+    darwin: getPathToBraveOnDarwin(),
+    win32: getPathToBraveOnWindows(),
     linux: getBin('brave')
   },
-  ENV_CMD: 'BRAVE'
+  ENV_CMD: 'BRAVE_BIN'
 }
 
 BraveBrowser.$inject = ['baseBrowserDecorator', 'args'];
 
 module.exports = {
   'launcher:Brave': ['type', BraveBrowser]
-}
+};

--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ function getBin(command) {
   if (process.platform !== 'linux') {
     return null;
   }
-
   try {
     return which.sync(command);
   }


### PR DESCRIPTION
This adds support for Darwin (MacOS) and a first stab at Windows support.  In the process, added a README.md and the same options processing that is in karma-vivaldi-launcher and karma-chrome-launcher.

Unfortunately, on Windows, it reports a couple errors when it starts, and while it brings up the karma display, it doesn't seem to be reporting well back through Karma.  So more work will be needed eventually on Windows.  (the README mentions that Windows support isn't fantastic)