### PR TITLE
feat(mac/windows) a humbled set of code for launching on mac and windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# karma-brave-launcher
+Launcher for [Brave](https://brave.com/)
+
+> NOTE: Windows support is not very good at the moment (meaning, very poor). Pull requests or pointers to docs to address this are welcomed.
+
+## Installation
+
+The easiest way is to keep `karma-brave-launcher` as a devDependency in your `package.json`,
+by running
+
+```bash
+$ npm install --save-dev karma-brave-launcher
+```
+
+## Configuration
+
+```js
+// karma.conf.js
+module.exports = function(config) {
+  config.set({
+    browsers: ['Brave']
+  })
+}
+```
+
+You can pass list of browsers as a CLI argument too:
+
+```bash
+$ karma start --browsers Brave
+```
+
+
+## References
+
+For more information on Karma see the [homepage](http://karma-runner.github.com)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ npm install --save-dev karma-brave-launcher
 module.exports = function(config) {
   config.set({
     browsers: ['Brave']
-  })
+  });
 }
 ```
 
@@ -29,6 +29,39 @@ You can pass list of browsers as a CLI argument too:
 $ karma start --browsers Brave
 ```
 
+### CustomLaunchers
+
+Karma allows you to pass other configuration options to the browser launchers.  You do this something like the following:
+
+```
+module.exports = function(config) {
+  config.set({
+    browsers: [ 'MyEpicBraveVariation' ],
+    customLaunchers: {
+      MyEpicBraveVariation: {
+        base: 'Brave',
+        dataDir: '/some/path',
+        flags: '--some-option=thing',
+        startupSettings: {
+          settings: {
+            'general.check-default-on-startup': false
+          },
+          someSetting: {
+          }
+        }
+      }
+    }
+  });
+} 
+```
+
+That is, you tell Karma to use the MyEpicBraveVersion "browser".  This, in turn, is defined in the configuration file as the base browser launcher (this one) with some addional configuration options.
+
+At this time, the Brave launcher supports three configuration options:
+
+* `dataDir`: The path to the location that the browser should store its data in. You should use this if you wanted to preserve state across testing sessions.  By default, this launcher will create a temporary directory for each run.
+* `flags`: Specify any command line flags.  These are in addition to the `--user-data-dir` and the URL to launch.
+* startupSettings: A JavaScript object that should be used to seed the Brave session store file (`${dataDir}/session-store-1`). By default, this launcher uses this to keep the Brave window from being full screen, and not checking if Brave is the default browser at startup time. Note: This is not a "public" interface in Brave, so naturally these settings may break between releases.
 
 ## References
 

--- a/index.js
+++ b/index.js
@@ -1,30 +1,76 @@
+var fs = require('fs');
+var path = require('path');
 var which = require('which');
 
-var BraveBrowser = function (baseBrowserDecorator, args) {
-  baseBrowserDecorator(this);
-
-};
+var WINDOWS_EXE_DIRS = [process.env.LOCALAPPDATA, process.env.PROGRAMFILES, process.env['PROGRAMFILES(X86)']];
+var WINDOWS_SUBPATH = '\\Brave\\Application\\brave.exe';
+var DARWIN_SUBPATH = 'Applications/Brave.app/Contents/MacOS/Brave';
 
 function getBin(command) {
   if (process.platform !== 'linux') {
     return null;
   }
+
   try {
     return which.sync(command);
   }
   catch(err){};
 }
 
+/*
+ * On darwin, try to find the browser at the path, relative to the 
+ * user's home directory, otherwise try to find it relative to the
+ * root directory
+ */
+function getPathToBraveOnDarwin(defaultPath) {
+  if (process.platform !== 'darwin') {
+    return;
+  }
+
+  var homePath = path.join(process.env.HOME, DARWIN_SUBPATH);
+  var rootPath = path.join('/', DARWIN_SUBPATH);
+
+  return fs.existsSync(homePath) ? homePath : rootPath;
+}
+
+/*
+ * On Windows, cycle through a set of special app locations, and look for it
+ * relative to those
+ */
+function getPathToBraveOnWindows() {
+  if (process.platform !== 'win32') {
+    return;
+  }
+
+  var windowsBraveDirectory;
+
+  for (var i = 0; i < WINDOWS_EXE_DIRS.length; i++) {
+    windowsBraveDirectory = path.join(prefixes[i], WINDOWS_SUBPATH);
+
+    if (fs.existsSync(windowsBraveDirectory)) {
+      return windowsBraveDirectory;
+    }
+  }
+
+  return windowsBraveDirectory;
+}
+
+function BraveBrowser(baseBrowserDecorator, args) {
+   baseBrowserDecorator(this);
+}
+
 BraveBrowser.prototype = {
   name: 'Brave',
   DEFAULT_CMD: {
+    darwin: getPathToBraveOnDarwin(),
+    win32: getPathToBraveOnWindows(),
     linux: getBin('brave')
   },
-  ENV_CMD: 'BRAVE'
+  ENV_CMD: 'BRAVE_BIN'
 }
 
 BraveBrowser.$inject = ['baseBrowserDecorator', 'args'];
 
 module.exports = {
   'launcher:Brave': ['type', BraveBrowser]
-}
+};

--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ function getBin(command) {
   if (process.platform !== 'linux') {
     return null;
   }
-
   try {
     return which.sync(command);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-brave-launcher",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Brave browser launcher for karma",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This is a pull request which adds support for launching Brave on Mac and Windows.  It is a bit fragile, which means it doesn't always work as well as I'd like (it launches the browser, but doesn't always suppress the "do you want to make this your default browser" message, and on windows brave reports some (evidently not important) errors to the console. As such, I'd understand if you didn't want to accept it.

At this point, my feeling is that I need to make a contribution back to the Brave browser itself, as my attempts to go behind it's back to suppress that startup message aren't robust, and I think the only way to deal with that is work with them. 